### PR TITLE
Ensure end screen hidden until game ends

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -60,6 +60,10 @@ canvas {
   text-align: center;
 }
 
+.panel[hidden] {
+  display: none !important;
+}
+
 .panel button {
   font-size: 1.2em;
   padding: 10px 20px;


### PR DESCRIPTION
## Summary
- Fix styles so the end screen panel stays hidden until the game ends by honoring the `hidden` attribute

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688dbac4cd58832388076e4b1f1f90bd