### PR TITLE
Enhance bike racing controls and scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,33 @@ Open <http://localhost:5000> in your browser.
 ## Deploy
 
 This app can be easily deployed to services such as Render or Heroku using the provided `requirements.txt` and `Procfile` style startup (`flask run`).
+
+## How to play Kids Bike Racing
+
+### Objective
+
+Ride your bike along the side-scrolling track, collecting stars and avoiding rocks while racing to the finish before time runs out.
+
+### Starting the game
+
+When the page loads, enter a name (optional) and click Play to begin.
+
+### Controls
+
+Accelerate: Hold the right-arrow key or tap/press the on-screen ▶ button to speed up
+
+Jump: Press the space bar or tap/press the on-screen ⬆ button to hop over obstacles
+
+Slow Down: Hold the down-arrow key or tap/press the on-screen ⬇ button to ride at a reduced speed
+
+Releasing the right-arrow key or lifting your finger from the ▶ button slows the bike to normal speed
+
+### Gameplay mechanics
+
+Grabbing a star increases your star count, while hitting a rock deducts 2 seconds from the timer
+
+You lose if the timer reaches zero and win by covering the required distance before time runs out
+
+### After the race
+
+Once the race ends, your score (based on remaining time and collected stars) is displayed alongside a leaderboard, with an option to play again

--- a/index.html
+++ b/index.html
@@ -12,9 +12,10 @@
   <div id="hud">
     <span id="hud-time">Time: 60</span>
     <span id="hud-stars">Stars: 0</span>
+    <span id="hud-score">Score: 0</span>
   </div>
   <div id="controls">
-    <button id="btnLeft">◀</button>
+    <button id="btnDown">⬇</button>
     <button id="btnRight">▶</button>
     <button id="btnJump">⬆</button>
   </div>


### PR DESCRIPTION
## Summary
- Extend race distance so the timer runs a full 60 seconds before finishing
- Display live score and add braking control via down arrow and ⬇ button
- Document full gameplay instructions and controls in README

## Testing
- `python -m py_compile app.py models.py`
- `node --check static/js/game.js`


------
https://chatgpt.com/codex/tasks/task_e_688dd9a169f883238d60274651150fef